### PR TITLE
Update s2builder.h comments

### DIFF
--- a/src/s2/s2builder.h
+++ b/src/s2/s2builder.h
@@ -281,10 +281,10 @@ class S2Builder {
     //
     // Note that if your input data includes vertices that were created using
     // S2::GetIntersection(), then you should use a "snap_radius" of
-    // at least S2::kIntersectionSnapRadius, e.g. by calling
+    // at least S2::kIntersectionMergeRadius, e.g. by calling
     //
     //  options.set_snap_function(s2builderutil::IdentitySnapFunction(
-    //      S2::kIntersectionSnapRadius));
+    //      S2::kIntersectionMergeRadius));
     //
     // DEFAULT: s2builderutil::IdentitySnapFunction(S1Angle::Zero())
     // [This does no snapping and preserves all input vertices exactly.]


### PR DESCRIPTION
kIntersectionSnapRadius is not defined anywhere.  The comments from s2edge_crossings.h for kIntersectionMergeRadius indicate this is what it meant.

// This value can be used as the S2Builder snap_radius() to ensure that edges // that have been displaced by up to kIntersectionError are merged back // together again.  For example this can happen when geometry is intersected // with a set of tiles and then unioned.  It is equal to twice the // intersection error because input edges might have been displaced in // opposite directions.
constexpr S1Angle kIntersectionMergeRadius = 2 * kIntersectionError;